### PR TITLE
Fixed subhead typo in https://web.dev/autowebperf/ blog

### DIFF
--- a/src/site/content/en/blog/autowebperf/index.md
+++ b/src/site/content/en/blog/autowebperf/index.md
@@ -1,9 +1,9 @@
 ---
 title: 'Automating audits with AutoWebPerf'
 subhead: >
-  A new modular tool that enables automatic gathering of performance data form multiple sources.
+  A new modular tool that enables automatic gathering of performance data from multiple sources.
 description: >
-  A new modular tool that enables automatic gathering of performance data form multiple sources.
+  A new modular tool that enables automatic gathering of performance data from multiple sources.
 date: 2020-12-09
 # updated: 2020-07-22
 authors:


### PR DESCRIPTION
Changed "form" to "from" in the subhead of https://web.dev/autowebperf/

<!-- Add the `DO NOT MERGE` label if you don't want the web.dev team 
     to merge this PR immediately after approving it. -->

Fixes #SOME_ISSUE_NUMBER

Changes proposed in this pull request:

- 
- 
- 
